### PR TITLE
Add support for L2OFF servers

### DIFF
--- a/L2ACP.sln
+++ b/L2ACP.sln
@@ -1,13 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.3
+VisualStudioVersion = 15.0.27004.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{67FBBA60-BC97-43EF-B275-B66973F7FFB8}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CBFBBA3A-5D21-4DF9-941D-3767C5C53AAA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "L2ACP", "src\L2ACP\L2ACP.csproj", "{9E68DE49-0A93-452B-A293-2FD5F8B1E844}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "L2ACP", "src\L2ACP\L2ACP.csproj", "{9E68DE49-0A93-452B-A293-2FD5F8B1E844}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,8 +15,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9E68DE49-0A93-452B-A293-2FD5F8B1E844}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E68DE49-0A93-452B-A293-2FD5F8B1E844}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E68DE49-0A93-452B-A293-2FD5F8B1E844}.Debug|Any CPU.ActiveCfg = Release|Any CPU
+		{9E68DE49-0A93-452B-A293-2FD5F8B1E844}.Debug|Any CPU.Build.0 = Release|Any CPU
 		{9E68DE49-0A93-452B-A293-2FD5F8B1E844}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9E68DE49-0A93-452B-A293-2FD5F8B1E844}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
@@ -25,5 +25,8 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{9E68DE49-0A93-452B-A293-2FD5F8B1E844} = {67FBBA60-BC97-43EF-B275-B66973F7FFB8}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {280D5A12-6A97-4ED3-A5DE-CA0A79BDDEF2}
 	EndGlobalSection
 EndGlobal

--- a/L2ACP.sln
+++ b/L2ACP.sln
@@ -15,8 +15,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9E68DE49-0A93-452B-A293-2FD5F8B1E844}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{9E68DE49-0A93-452B-A293-2FD5F8B1E844}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{9E68DE49-0A93-452B-A293-2FD5F8B1E844}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E68DE49-0A93-452B-A293-2FD5F8B1E844}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9E68DE49-0A93-452B-A293-2FD5F8B1E844}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9E68DE49-0A93-452B-A293-2FD5F8B1E844}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -17,3 +17,12 @@ This is the web interface project for L2ACP
 git clone https://github.com/Elfocrash/L2ACP-Web.git
 ```
 2. Open Visual Studio, do a `dotnet restore` and then publish the project.
+
+## L2OFF Configuration
+* Install L2OFF server database
+* Run L2OFF_L2ACP.SQL script to modify lin2world and lin2db database
+* Change appsettings.json:
+** Set TargetServerType to "L2OFF"
+** Set PasswordHashType to "Default" if using default password hashing or "MD5" if using hAuthD's MD5 hashing
+** Set appropriate connection strings for the lin2world and lin2db databases
+* In server's ilExt.ini set "[PrivateStore] StoreInDB=1" for private stores and "[ItemDelivery] Enabled=1" for item delivery

--- a/src/L2ACP/Controllers/AccountController.cs
+++ b/src/L2ACP/Controllers/AccountController.cs
@@ -72,8 +72,6 @@ namespace L2ACP.Controllers
             
             if (ModelState.IsValid)
             {
-                System.Diagnostics.Debug.WriteLine("Model password: " + model.Password);
-
                 var response = await _requestService.LoginUser(model.Username, model.Password.ToL2Password());
 
                 if (response.ResponseCode == 200)

--- a/src/L2ACP/Controllers/AccountController.cs
+++ b/src/L2ACP/Controllers/AccountController.cs
@@ -19,6 +19,7 @@ using L2ACP.Models;
 using L2ACP.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
+using System;
 
 namespace L2ACP.Controllers
 {
@@ -68,9 +69,11 @@ namespace L2ACP.Controllers
             ViewData["ReturnUrl"] = returnUrl;
             if (User.Identity.IsAuthenticated)
                 return Redirect("/");
-
+            
             if (ModelState.IsValid)
             {
+                System.Diagnostics.Debug.WriteLine("Model password: " + model.Password);
+
                 var response = await _requestService.LoginUser(model.Username, model.Password.ToL2Password());
 
                 if (response.ResponseCode == 200)

--- a/src/L2ACP/Controllers/AdminController.cs
+++ b/src/L2ACP/Controllers/AdminController.cs
@@ -46,7 +46,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return RedirectToAction("Login", "Account");
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return RedirectToAction("Login", "Account");
 
             return View();
@@ -58,7 +58,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return RedirectToAction("Login", "Account");
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return RedirectToAction("Login", "Account");
 
             var playersData = await _requestService.GetAnalyticsPlayers() as GetAnalyticsPlayersResponse;
@@ -74,7 +74,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return RedirectToAction("Login", "Account");
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return RedirectToAction("Login", "Account");
 
             var getBuyList = await _requestService.GetBuyList() as GetBuyListResponse;
@@ -94,7 +94,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return RedirectToAction("Login", "Account");
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return RedirectToAction("Login", "Account");
 
             var allPlayers = await _requestService.GetAllPlayers() as GetAllPlayerNamesResponse;
@@ -108,7 +108,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return RedirectToAction("Login", "Account");
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return RedirectToAction("Login", "Account");
 
             return PartialView("_ServerManagment");
@@ -120,7 +120,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return RedirectToAction("Login", "Account");
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return RedirectToAction("Login", "Account");
 
             return PartialView("_LiveMap");
@@ -132,7 +132,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return RedirectToAction("Login", "Account");
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return RedirectToAction("Login", "Account");
 
             var response = await _requestService.GetAllOnlinePlayersForMap() as GetAllOnlinePlayersForMapResponse;
@@ -144,6 +144,8 @@ namespace L2ACP.Controllers
                 {
                     player.X = (int) Math.Round((double)(116 + (player.X + 107823) / 200));
                     player.Y = (int)Math.Round((double)(2580 + (player.Y - 255420) / 200));
+
+                    System.Diagnostics.Debug.WriteLine("X: " + player.X + ", Y: " + player.Y);
                 }
 
                 return new JsonResult(players);
@@ -159,7 +161,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return Content(_localizer["You need to be logged in"]);
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return Content(_localizer["Not enough access level"]);
 
             var response = await _requestService.GiveItem(model.Username, model.ItemId, model.ItemCount, model.Enchant);
@@ -178,7 +180,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return Content(_localizer["You need to be logged in"]);
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return Content(_localizer["Not enough access level"]);
 
             var text = Request.Form["annText"];
@@ -198,7 +200,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return Content(_localizer["You need to be logged in"]);
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return Content(_localizer["Not enough access level"]);
 
             var playerName = Request.Form["Username"];
@@ -219,7 +221,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return Content(_localizer["You need to be logged in"]);
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return Content(_localizer["Not enough access level"]);
 
             var playerName = Request.Form["Username"];
@@ -250,7 +252,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return Content(_localizer["You need to be logged in"]);
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return Content(_localizer["Not enough access level"]);
 
             if (!int.TryParse(Request.Form["restartseconds"], out int seconds))
@@ -271,7 +273,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return Content(_localizer["You need to be logged in"]);
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return Content(_localizer["Not enough access level"]);
 
             var response = await _requestService.SetDonateList(items);
@@ -289,7 +291,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return Content(_localizer["You need to be logged in"]);
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return Content(_localizer["Not enough access level"]);
 
             var npcId = int.Parse(Request.Form["NpcId"]);
@@ -311,7 +313,7 @@ namespace L2ACP.Controllers
             if (!User.Identity.IsAuthenticated)
                 return Content(_localizer["You need to be logged in"]);
 
-            if (HttpContext.GetAccountInfo()?.AccessLevel < 100)
+            if (!HttpContext.HasAdminAccess())
                 return Content(_localizer["Not enough access level"]);
 
             var punishId = int.Parse(Request.Form["PunishId"]);

--- a/src/L2ACP/Controllers/HomeController.cs
+++ b/src/L2ACP/Controllers/HomeController.cs
@@ -541,7 +541,7 @@ namespace L2ACP.Controllers
             {
                 var accountName = HttpContext.GetUsername();
 
-                var response = await _requestService.ChangePassword(accountName, model.CurrentPassword.ToL2Password(), model.NewPassword.ToL2Password());
+                var response = await _requestService.ChangePassword(accountName, model.CurrentPassword.ToLegacyL2Password(), model.NewPassword.ToL2Password());
                 switch (response.ResponseCode)
                 {
                     case 200:

--- a/src/L2ACP/Cryptography/L2OffCrypto.cs
+++ b/src/L2ACP/Cryptography/L2OffCrypto.cs
@@ -1,0 +1,119 @@
+﻿/*
+ * Copyright (C) 2018 Petr Jasicek
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ * 
+ * L2ACP is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace L2ACP.Cryptography
+{
+    public class L2OffCrypto
+    {
+        public static string EncryptLegacyL2Password(string password)
+        {
+            var key = new byte[16];
+            long one, two, three, four;
+            var dst = new byte[16];
+            var nBytes = password.Length;
+
+            for (var i = 0; i < nBytes; i++)
+            {
+                key[i] = System.Text.Encoding.ASCII.GetBytes(password.Substring(i, 1))[0];
+                dst[i] = key[i];
+            }
+
+            long rslt = @key[0] + @key[1] * 256 + @key[2] * 65536 + @key[3] * 16777216;
+            one = rslt * 213119 + 2529077;
+            one = one - ToInt32(one / 4294967296) * 4294967296;
+
+            rslt = @key[4] + @key[5] * 256 + @key[6] * 65536 + @key[7] * 16777216;
+            two = rslt * 213247 + 2529089;
+            two = two - ToInt32(two / 4294967296) * 4294967296;
+
+            rslt = @key[8] + @key[9] * 256 + @key[10] * 65536 + @key[11] * 16777216;
+            three = rslt * 213203 + 2529589;
+            three = three - ToInt32(three / 4294967296) * 4294967296;
+
+            rslt = @key[12] + @key[13] * 256 + @key[14] * 65536 + @key[15] * 16777216;
+            four = rslt * 213821 + 2529997;
+            four = four - ToInt32(four / 4294967296) * 4294967296;
+
+            key[3] = ParseInt(one / 16777216);
+            key[2] = ParseInt((((Int32)(one - @key[3] * 16777216)) / 65535));
+            key[1] = ParseInt((one - @key[3] * 16777216 - @key[2] * 65536) / 256);
+            key[0] = ParseInt((one - @key[3] * 16777216 - @key[2] * 65536 - @key[1] * 256));
+
+            key[7] = ParseInt(two / 16777216);
+            key[6] = ParseInt((two - @key[7] * 16777216) / 65535);
+            key[5] = ParseInt((two - @key[7] * 16777216 - @key[6] * 65536) / 256);
+            key[4] = ParseInt((two - @key[7] * 16777216 - @key[6] * 65536 - @key[5] * 256));
+
+            key[11] = ParseInt(three / 16777216);
+            key[10] = ParseInt((three - @key[11] * 16777216) / 65535);
+            key[9] = ParseInt((three - @key[11] * 16777216 - @key[10] * 65536) / 256);
+            key[8] = ParseInt((three - @key[11] * 16777216 - @key[10] * 65536 - @key[9] * 256));
+
+            key[15] = ParseInt(four / 16777216);
+            key[14] = ParseInt((four - @key[15] * 16777216) / 65535);
+            key[13] = ParseInt((four - @key[15] * 16777216 - @key[14] * 65536) / 256);
+            key[12] = ParseInt((four - @key[15] * 16777216 - @key[14] * 65536 - @key[13] * 256));
+
+            dst[0] = ParseInt(dst[0] ^ @key[0]);
+
+            for (var i = 1; i < dst.Length; i++)
+                dst[i] = ParseInt(@dst[i] ^ @dst[i - 1] ^ @key[i]);
+
+            for (var i = 0; i < dst.Length; i++)
+                if (dst[i] == 0)
+                    dst[i] = 102;
+
+            return L2ACP.Extensions.GeneralExtensions.ByteArrayToString(dst);
+        }
+
+        private static int ToInt32(long val)
+        {
+            return Convert.ToInt32(val);
+        }
+
+        private static byte ParseInt(long val)
+        {
+            return BitConverter.GetBytes(val)[0];
+        }
+
+        private static string EncryptMD5L2Password(string password)
+        {
+            var md5Password = password.ToCharArray();
+            var s = (EncryptMD5(password) + EncryptMD5(password)).ToCharArray();
+            int j = 0;
+            for (var i = 0; i < s.Length; i++)
+            {
+                if (j >= password.Length) j = 0;
+
+                var calcu = s[i] ^ md5Password[j];
+                s[i] = (char)calcu;
+                j++;
+            }
+            return EncryptMD5(new string(s));
+        }
+
+
+        public static string EncryptMD5(string originalPassword)
+        {
+            return BitConverter.ToString(((System.Security.Cryptography.MD5.Create()).ComputeHash(System.Text.Encoding.UTF8.GetBytes(originalPassword)))).Replace("-", "").ToLower();
+        }
+    }
+}

--- a/src/L2ACP/L2ACP.csproj
+++ b/src/L2ACP/L2ACP.csproj
@@ -10,54 +10,12 @@
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="wwwroot\css\plugins\footable\fonts\footable.eot" />
-    <Content Include="wwwroot\css\plugins\footable\fonts\footable.svg" />
-    <Content Include="wwwroot\css\plugins\footable\fonts\footable.ttf" />
-    <Content Include="wwwroot\css\plugins\footable\fonts\footable.woff" />
-    <Content Include="wwwroot\css\plugins\footable\footable.core.css" />
-    <Content Include="wwwroot\css\plugins\morris\morris-0.4.3.min.css" />
-    <Content Include="wwwroot\images\0.gif" />
-    <Content Include="wwwroot\images\background.png" />
-    <Content Include="wwwroot\images\border.png" />
-    <Content Include="wwwroot\images\buttons.png" />
-    <Content Include="wwwroot\images\button_bg.png" />
-    <Content Include="wwwroot\images\cover.png" />
-    <Content Include="wwwroot\images\gear.png" />
-    <Content Include="wwwroot\images\gears.gif" />
-    <Content Include="wwwroot\images\Itemname_bg.png" />
-    <Content Include="wwwroot\images\loading.png" />
-    <Content Include="wwwroot\images\map.jpg" />
-    <Content Include="wwwroot\images\mark.gif" />
-    <Content Include="wwwroot\images\Popup_bg.png" />
-    <Content Include="wwwroot\images\privatebuy.png" />
-    <Content Include="wwwroot\images\privatesell.png" />
-    <Content Include="wwwroot\images\win.png" />
-    <Content Include="wwwroot\images\Win_Effect.png" />
-    <Content Include="wwwroot\js\footable\footable.all.min.js" />
-    <Content Include="wwwroot\js\i18next.min.js" />
-    <Content Include="wwwroot\js\morris\morris.js" />
-    <Content Include="wwwroot\js\morris\raphael-2.1.0.min.js" />
-    <Content Include="wwwroot\xml\npcs\12000-12999.xml" />
-    <Content Include="wwwroot\xml\npcs\13000-13999.xml" />
-    <Content Include="wwwroot\xml\npcs\14000-14999.xml" />
-    <Content Include="wwwroot\xml\npcs\16000-16999.xml" />
-    <Content Include="wwwroot\xml\npcs\18000-18999.xml" />
-    <Content Include="wwwroot\xml\npcs\20000-20999.xml" />
-    <Content Include="wwwroot\xml\npcs\21000-21999.xml" />
-    <Content Include="wwwroot\xml\npcs\22000-22999.xml" />
-    <Content Include="wwwroot\xml\npcs\25000-25999.xml" />
-    <Content Include="wwwroot\xml\npcs\27000-27999.xml" />
-    <Content Include="wwwroot\xml\npcs\29000-29999.xml" />
-    <Content Include="wwwroot\xml\npcs\30000-30999.xml" />
-    <Content Include="wwwroot\xml\npcs\31000-31999.xml" />
-    <Content Include="wwwroot\xml\npcs\32000-32999.xml" />
-    <Content Include="wwwroot\xml\npcs\35000-35999.xml" />
-    <Content Include="wwwroot\xml\npcs\50000-50999.xml" />
-  </ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>DEBUG;TRACE;RELEASE;NETCOREAPP1_1</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
-    <None Update="wwwroot\**\*;Views\**\*;Areas\**\Views">
+    <None Update="Views\**\*;Areas\**\Views">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
   </ItemGroup>
@@ -83,10 +41,7 @@
     <PackageReference Include="system.xml.xpath.xmldocument" Version="4.0.0" />
   </ItemGroup>
 
-  <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
-    <Exec Command="bower install" />
-    <Exec Command="dotnet bundle" />
-  </Target>
+  
 
   <ItemGroup>
     <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.2.301" />
@@ -94,6 +49,92 @@
 
   <ItemGroup>
     <Folder Include="Models\BusinessModels\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="wwwroot\css\bootstrap.css.map" />
+    <None Include="wwwroot\css\bootstrap.min.css.map" />
+    <None Include="wwwroot\css\less\badges_labels.less" />
+    <None Include="wwwroot\css\less\base.less" />
+    <None Include="wwwroot\css\less\buttons.less" />
+    <None Include="wwwroot\css\less\chat.less" />
+    <None Include="wwwroot\css\less\custom.less" />
+    <None Include="wwwroot\css\less\elements.less" />
+    <None Include="wwwroot\css\less\landing.less" />
+    <None Include="wwwroot\css\less\md-skin.less" />
+    <None Include="wwwroot\css\less\media.less" />
+    <None Include="wwwroot\css\less\metismenu.less" />
+    <None Include="wwwroot\css\less\mixins.less" />
+    <None Include="wwwroot\css\less\navigation.less" />
+    <None Include="wwwroot\css\less\pages.less" />
+    <None Include="wwwroot\css\less\rtl.less" />
+    <None Include="wwwroot\css\less\sidebar.less" />
+    <None Include="wwwroot\css\less\skins.less" />
+    <None Include="wwwroot\css\less\spinners.less" />
+    <None Include="wwwroot\css\less\style.less" />
+    <None Include="wwwroot\css\less\theme-config.less" />
+    <None Include="wwwroot\css\less\top_navigation.less" />
+    <None Include="wwwroot\css\less\typography.less" />
+    <None Include="wwwroot\css\less\variables.less" />
+    <None Include="wwwroot\css\plugins\footable\fonts\footable.svg" />
+    <None Include="wwwroot\font-awesome\fonts\fontawesome-webfont.svg" />
+    <None Include="wwwroot\font-awesome\fonts\fontawesome-webfont.woff2" />
+    <None Include="wwwroot\font-awesome\less\animated.less" />
+    <None Include="wwwroot\font-awesome\less\bordered-pulled.less" />
+    <None Include="wwwroot\font-awesome\less\core.less" />
+    <None Include="wwwroot\font-awesome\less\fixed-width.less" />
+    <None Include="wwwroot\font-awesome\less\font-awesome.less" />
+    <None Include="wwwroot\font-awesome\less\icons.less" />
+    <None Include="wwwroot\font-awesome\less\larger.less" />
+    <None Include="wwwroot\font-awesome\less\list.less" />
+    <None Include="wwwroot\font-awesome\less\mixins.less" />
+    <None Include="wwwroot\font-awesome\less\path.less" />
+    <None Include="wwwroot\font-awesome\less\rotated-flipped.less" />
+    <None Include="wwwroot\font-awesome\less\screen-reader.less" />
+    <None Include="wwwroot\font-awesome\less\stacked.less" />
+    <None Include="wwwroot\font-awesome\less\variables.less" />
+    <None Include="wwwroot\font-awesome\scss\font-awesome.scss" />
+    <None Include="wwwroot\font-awesome\scss\_animated.scss" />
+    <None Include="wwwroot\font-awesome\scss\_bordered-pulled.scss" />
+    <None Include="wwwroot\font-awesome\scss\_core.scss" />
+    <None Include="wwwroot\font-awesome\scss\_fixed-width.scss" />
+    <None Include="wwwroot\font-awesome\scss\_icons.scss" />
+    <None Include="wwwroot\font-awesome\scss\_larger.scss" />
+    <None Include="wwwroot\font-awesome\scss\_list.scss" />
+    <None Include="wwwroot\font-awesome\scss\_mixins.scss" />
+    <None Include="wwwroot\font-awesome\scss\_path.scss" />
+    <None Include="wwwroot\font-awesome\scss\_rotated-flipped.scss" />
+    <None Include="wwwroot\font-awesome\scss\_screen-reader.scss" />
+    <None Include="wwwroot\font-awesome\scss\_stacked.scss" />
+    <None Include="wwwroot\font-awesome\scss\_variables.scss" />
+    <None Include="wwwroot\js\footable\footable.all.min.js" />
+    <None Include="wwwroot\js\i18next.min.js" />
+    <None Include="wwwroot\js\morris\morris.js" />
+    <None Include="wwwroot\js\morris\raphael-2.1.0.min.js" />
+    <None Include="wwwroot\js\select2.full.min.js" />
+    <None Include="wwwroot\js\site.js" />
+    <None Include="wwwroot\js\site.min.js" />
+    <None Include="wwwroot\lib\bootstrap\dist\css\bootstrap-theme.css.map" />
+    <None Include="wwwroot\lib\bootstrap\dist\css\bootstrap-theme.min.css.map" />
+    <None Include="wwwroot\lib\bootstrap\dist\css\bootstrap.css.map" />
+    <None Include="wwwroot\lib\bootstrap\dist\css\bootstrap.min.css.map" />
+    <None Include="wwwroot\lib\bootstrap\dist\fonts\glyphicons-halflings-regular.svg" />
+    <None Include="wwwroot\lib\bootstrap\dist\fonts\glyphicons-halflings-regular.woff2" />
+    <None Include="wwwroot\lib\bootstrap\dist\js\bootstrap.js" />
+    <None Include="wwwroot\lib\bootstrap\dist\js\bootstrap.min.js" />
+    <None Include="wwwroot\lib\bootstrap\dist\js\npm.js" />
+    <None Include="wwwroot\lib\bootstrap\LICENSE" />
+    <None Include="wwwroot\lib\jquery-validation-unobtrusive\jquery.validate.unobtrusive.js" />
+    <None Include="wwwroot\lib\jquery-validation-unobtrusive\jquery.validate.unobtrusive.min.js" />
+    <None Include="wwwroot\lib\jquery-validation\dist\additional-methods.js" />
+    <None Include="wwwroot\lib\jquery-validation\dist\additional-methods.min.js" />
+    <None Include="wwwroot\lib\jquery-validation\dist\jquery.validate.js" />
+    <None Include="wwwroot\lib\jquery-validation\dist\jquery.validate.min.js" />
+    <None Include="wwwroot\lib\jquery-validation\LICENSE.md" />
+    <None Include="wwwroot\lib\jquery\dist\jquery.js" />
+    <None Include="wwwroot\lib\jquery\dist\jquery.min.js" />
+    <None Include="wwwroot\lib\jquery\dist\jquery.min.map" />
+    <None Include="wwwroot\_references.js" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/L2ACP/Resources/Views/Home/Statistics.en-GB.resx
+++ b/src/L2ACP/Resources/Views/Home/Statistics.en-GB.resx
@@ -123,6 +123,9 @@
   <data name="days" xml:space="preserve">
     <value>days</value>
   </data>
+  <data name="hours" xml:space="preserve">
+    <value>hours</value>
+  </data>
   <data name="Level" xml:space="preserve">
     <value>Level</value>
   </data>

--- a/src/L2ACP/Resources/Views/Home/Statistics.pt-BR.resx
+++ b/src/L2ACP/Resources/Views/Home/Statistics.pt-BR.resx
@@ -123,6 +123,9 @@
   <data name="days" xml:space="preserve">
     <value>dias</value>
   </data>
+  <data name="hours" xml:space="preserve">
+    <value>hours</value>
+  </data>
   <data name="Level" xml:space="preserve">
     <value>Níveis</value>
   </data>

--- a/src/L2ACP/SQL/L2OFF_L2ACP.SQL
+++ b/src/L2ACP/SQL/L2OFF_L2ACP.SQL
@@ -1,0 +1,101 @@
+use lin2db
+go
+
+ALTER  TABLE user_auth add donatepoints int NOT NULL DEFAULT 0;
+
+use lin2world
+go
+
+ALTER  TABLE npc_boss add level int NOT NULL DEFAULT 1;
+
+-- ----------------------------
+-- Table structure for l2acp_donateitems
+-- ----------------------------
+DROP TABLE IF EXISTS l2acp_donateitems;
+CREATE TABLE l2acp_donateitems (
+  itemId int NOT NULL,
+  itemCount int NOT NULL DEFAULT '1',
+  enchant int NOT NULL DEFAULT '0',
+  price int NOT NULL DEFAULT '0'
+)
+
+-- ----------------------------
+-- Records of l2acp_donateitems
+-- ----------------------------
+INSERT INTO l2acp_donateitems VALUES ('57', '100000', '0', '1');
+INSERT INTO l2acp_donateitems VALUES ('6608', '1', '16', '1');
+INSERT INTO l2acp_donateitems VALUES ('6598', '1', '16', '5');
+INSERT INTO l2acp_donateitems VALUES ('6373', '1', '16', '5');
+INSERT INTO l2acp_donateitems VALUES ('6379', '1', '0', '5');
+INSERT INTO l2acp_donateitems VALUES ('5779', '1', '16', '5');
+INSERT INTO l2acp_donateitems VALUES ('5767', '1', '16', '5');
+INSERT INTO l2acp_donateitems VALUES ('512', '1', '16', '5');
+INSERT INTO l2acp_donateitems VALUES ('2407', '1', '16', '5');
+
+-- ----------------------------
+-- Table structure for l2acp_donateservices
+-- ----------------------------
+DROP TABLE IF EXISTS l2acp_donateservices
+CREATE TABLE l2acp_donateservices (
+  serviceid int NOT NULL,
+  servicename varchar(30) NOT NULL,
+  price int NOT NULL DEFAULT '0',
+  PRIMARY KEY (serviceid)
+);
+
+-- ----------------------------
+-- Records of l2acp_donateservices
+-- ----------------------------
+INSERT INTO l2acp_donateservices VALUES ('1', 'Change player''s name', '1');
+INSERT INTO l2acp_donateservices VALUES ('2', 'Set player nobless', '1');
+INSERT INTO l2acp_donateservices VALUES ('3', 'Reset player''s PK', '1');
+INSERT INTO l2acp_donateservices VALUES ('4', 'Change player''s sex', '1');
+
+-- ----------------------------
+-- Table structure for l2acp_donations
+-- ----------------------------
+DROP TABLE IF EXISTS l2acp_donations;
+CREATE TABLE l2acp_donations (
+  id int NOT NULL IDENTITY(1, 1),
+  accountName varchar(20) NOT NULL,
+  amount int DEFAULT NULL,
+  transactionid varchar(60) DEFAULT NULL,
+  verificationSign varchar(60) DEFAULT NULL,
+  PRIMARY KEY (id)
+);
+
+-- ----------------------------
+-- Table structure for l2acp_luckywheelitems
+-- ----------------------------
+DROP TABLE IF EXISTS l2acp_luckywheelitems;
+CREATE TABLE l2acp_luckywheelitems (
+  itemid int NOT NULL,
+  itemcount int DEFAULT '1',
+  enchant int DEFAULT '0',
+  chance float DEFAULT '0'
+);
+
+-- ----------------------------
+-- Records of l2acp_luckywheelitems
+-- ----------------------------
+INSERT INTO l2acp_luckywheelitems VALUES ('6375', '1', '0', '8.33');
+INSERT INTO l2acp_luckywheelitems VALUES ('6376', '1', '0', '8.33');
+INSERT INTO l2acp_luckywheelitems VALUES ('6377', '1', '0', '8.33');
+INSERT INTO l2acp_luckywheelitems VALUES ('6378', '1', '0', '8.33');
+INSERT INTO l2acp_luckywheelitems VALUES ('6379', '1', '0', '8.33');
+INSERT INTO l2acp_luckywheelitems VALUES ('6380', '1', '0', '8.33');
+INSERT INTO l2acp_luckywheelitems VALUES ('6381', '1', '0', '8.33');
+INSERT INTO l2acp_luckywheelitems VALUES ('6382', '1', '0', '8.33');
+INSERT INTO l2acp_luckywheelitems VALUES ('6383', '1', '0', '8.33');
+INSERT INTO l2acp_luckywheelitems VALUES ('6384', '1', '0', '8.33');
+INSERT INTO l2acp_luckywheelitems VALUES ('7575', '1', '0', '8.33');
+INSERT INTO l2acp_luckywheelitems VALUES ('7576', '1', '0', '8.33');
+
+-- ----------------------------
+-- Table structure for l2acp_onlineanalytics
+-- ----------------------------
+DROP TABLE IF EXISTS l2acp_onlineanalytics;
+CREATE TABLE l2acp_onlineanalytics (
+  playercount int NOT NULL,
+  recordedtime bigint NOT NULL
+);

--- a/src/L2ACP/Services/DatabaseRequestService.cs
+++ b/src/L2ACP/Services/DatabaseRequestService.cs
@@ -1,0 +1,1462 @@
+﻿/*
+ * Copyright (C) 2018 Petr Jasicek
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ * 
+ * L2ACP is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using L2ACP.Extensions;
+using L2ACP.Models;
+using L2ACP.Requests;
+using L2ACP.Responses;
+using Newtonsoft.Json;
+using System.Data.Common;
+using System.Data.SqlClient;
+using System.Data;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
+using System.Text.RegularExpressions;
+
+namespace L2ACP.Services
+{
+    public class DatabaseRequestService : IRequestService
+    {
+        private static string LIN2WORLD_CONN_STRING = Startup.Configuration.GetValue<string>("ConnectionString_lin2world");
+        private static string LIN2USER_CONN_STRING = Startup.Configuration.GetValue<string>("ConnectionString_lin2user");
+        private static string LIN2DB_CONN_STRING = Startup.Configuration.GetValue<string>("ConnectionString_lin2db");
+
+        public async Task<L2Response> LoginUser(string username, string password)
+        {
+            System.Diagnostics.Debug.WriteLine("Requested username: " + username + ", Requested password: " + password);
+
+            L2Response response = new L2Response();
+            try
+            {
+                using (SqlConnection lin2dbDbConn = new SqlConnection(LIN2DB_CONN_STRING))
+                {
+                    lin2dbDbConn.Open();
+
+                    using (SqlCommand cmd = lin2dbDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT * FROM user_auth WHERE account = @USER";
+                        cmd.Parameters.AddWithValue("@USER", username);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                string dbPasswordHash = GeneralExtensions.ByteArrayToString((byte[])reader["password"]);
+                                if (password == dbPasswordHash)
+                                {
+                                    System.Diagnostics.Debug.WriteLine("Matching passwords !");
+                                    response.ResponseCode = 200;
+                                    response.ResponseMessage = "OK";
+                                }
+                                else
+                                {
+                                    System.Diagnostics.Debug.WriteLine("NOT MATCHING PASSWORDS !");
+
+                                    response.ResponseCode = 500;
+                                    response.ResponseMessage = "INVALID PASSWORD";
+                                }
+                            }
+                            else
+                            {
+                                response.ResponseCode = 500;
+                                response.ResponseMessage = "USER NOT FOUND";
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public static byte[] ConvertHexStringToByteArray(string hexString)
+        {
+            if (hexString.Length % 2 != 0)
+            {
+                throw new ArgumentException(String.Format(CultureInfo.InvariantCulture, "The binary key cannot have an odd number of digits: {0}", hexString));
+            }
+
+            byte[] HexAsBytes = new byte[hexString.Length / 2];
+            for (int index = 0; index < HexAsBytes.Length; index++)
+            {
+                string byteValue = hexString.Substring(index * 2, 2);
+                HexAsBytes[index] = byte.Parse(byteValue, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            }
+
+            return HexAsBytes;
+        }
+
+        public async Task<L2Response> RegisterUser(string username, string password)
+        {
+            L2Response response = new L2Response();
+            try
+            {
+                using (SqlConnection lin2dbDbConn = new SqlConnection(LIN2DB_CONN_STRING))
+                {
+                    lin2dbDbConn.Open();
+
+                    using (SqlCommand cmd = lin2dbDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT * FROM user_auth WHERE account = @USER";
+                        cmd.Parameters.AddWithValue("@USER", username);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                response.ResponseCode = 1000;
+                                response.ResponseMessage = "Account with username: " + username + " already exists";
+                                return response;
+                            }
+                        }
+                    }
+
+                    using (SqlCommand cmd = lin2dbDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "INSERT INTO user_auth (account, password, quiz1, quiz2, answer1, answer2) values (@USERNAME, @PASSWORD, @QUIZ1, @QUIZ2, @ANSWER1, @ANSWER2)";
+                        cmd.Parameters.AddWithValue("@USERNAME", username);
+                        cmd.Parameters.AddWithValue("@PASSWORD", ConvertHexStringToByteArray(password));
+                        cmd.Parameters.AddWithValue("@QUIZ1", "");
+                        cmd.Parameters.AddWithValue("@QUIZ2", "");
+                        cmd.Parameters.AddWithValue("@ANSWER1", ConvertHexStringToByteArray("00"));
+                        cmd.Parameters.AddWithValue("@ANSWER2", ConvertHexStringToByteArray("00"));
+
+                        if (cmd.ExecuteNonQuery() == 1)
+                        {
+                            response.ResponseCode = 200;
+                            response.ResponseMessage = "Successful registration";
+                        }
+                        else
+                        {
+                            response.ResponseCode = 500;
+                            response.ResponseMessage = "Unsuccessful registration";
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            System.Diagnostics.Debug.WriteLine("Registration. Reponse code: " + response.ResponseCode + ", Response message: " + response.ResponseMessage);
+
+            return response;
+        }
+
+        public async Task<L2Response> GetAccountInfo(string username)
+        {
+            GetAccountInfoResponse response = new GetAccountInfoResponse();
+            response.DonatePoints = 0;
+            response.AccessLevel = 0;
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT * FROM user_data WHERE account_name = @USER";
+                        cmd.Parameters.AddWithValue("@USER", username);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            List<string> charNames = new List<string>();
+                            while (reader.Read())
+                            {
+                                charNames.Add(reader["char_name"].ToString());
+                            }
+                            response.AccountNames = charNames.ToArray();
+                        }
+                    }
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT * FROM builder_account WHERE account_name = @USER";
+                        cmd.Parameters.AddWithValue("@USER", username);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                response.AccessLevel = reader.GetInt32(reader.GetOrdinal("default_builder"));
+                            }
+                        }
+                    }
+
+                    response.ResponseCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            response.DonatePoints = DatabaseServiceHelper.GetNumDonatePoints(username);
+            if (response.DonatePoints == -1)
+            {
+                response.ResponseCode = 500;
+                response.ResponseMessage = "Failed get donate points from account: " + username;
+                System.Diagnostics.Debug.WriteLine(response.ResponseMessage);
+            }
+
+            System.Diagnostics.Debug.WriteLine("ReponseCode: " + response.ResponseCode + ", AccessLevel: " + response.AccessLevel);
+
+            return response;
+        }
+
+        public async Task<L2Response> GetInventory(string player)
+        {
+            GetInventoryResponse response = new GetInventoryResponse();
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    // First get character id from character (player) name
+                    int charId = -1;
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT char_id FROM user_data WHERE char_name = @CHARNAME";
+                        cmd.Parameters.AddWithValue("@CHARNAME", player);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                charId = reader.GetInt32(reader.GetOrdinal("char_id"));
+                            }
+                        }
+                    }
+
+                    if (charId == -1)
+                    {
+                        response.ResponseCode = 500;
+                        response.ResponseMessage = "Could not find character ID for player: " + player;
+                        return response;
+                    }
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT * FROM user_item WHERE char_id = @CHAR_ID";
+                        cmd.Parameters.AddWithValue("@CHAR_ID", charId);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            List<InventoryInfo> inventoryList = new List<InventoryInfo>();
+                            while (reader.Read())
+                            {
+                                InventoryInfo item = new InventoryInfo();
+                                item.ObjectId = reader.GetInt32(reader.GetOrdinal("item_id"));
+                                item.ItemId = reader.GetInt32(reader.GetOrdinal("item_type"));
+                                item.ItemCount = reader.GetInt32(reader.GetOrdinal("amount"));
+                                item.Equipped = false; // This is not in L2Off database (?)
+                                item.Enchant = reader.GetInt32(reader.GetOrdinal("enchant"));
+
+                                inventoryList.Add(item);
+                            }
+                            response.InventoryInfo = inventoryList.ToArray();
+                        }
+                    }
+
+                    response.ResponseCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            System.Diagnostics.Debug.WriteLine("GetInventory. ReponseCode: " + response.ResponseCode + ", InventoryItemCount: " + response.InventoryInfo.Length);
+
+            return response;
+        }
+
+        public async Task<L2Response> GetPlayerInfo(string playerName)
+        {
+            GetPlayerInfoResponse response = new GetPlayerInfoResponse();
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT * FROM user_data WHERE char_name = @CHAR_NAME";
+                        cmd.Parameters.AddWithValue("@CHAR_NAME", playerName);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            response.PlayerInfo = new PlayerInfo();
+                            if (reader.Read())
+                            {
+                                response.PlayerInfo.Name = reader["char_name"].ToString();
+                                response.PlayerInfo.Title = "";
+                                response.PlayerInfo.Level = reader.GetByte(reader.GetOrdinal("Lev"));
+                                response.PlayerInfo.Pvp = reader.GetInt32(reader.GetOrdinal("Duel"));
+                                response.PlayerInfo.Pk = reader.GetInt32(reader.GetOrdinal("PK"));
+                                response.PlayerInfo.Sex = (int)reader.GetByte(reader.GetOrdinal("gender"));
+                                response.PlayerInfo.Race = (int)reader.GetByte(reader.GetOrdinal("class"));
+                                int pledgeId = reader.GetInt32(reader.GetOrdinal("pledge_id"));
+                                response.PlayerInfo.ClanName = DatabaseServiceHelper.GetClanNameFromPledgeId(pledgeId); 
+                                response.PlayerInfo.AllyName = DatabaseServiceHelper.GetAllianceNameFromPledgeId(pledgeId);
+                                response.PlayerInfo.Hero = false; // Can be probably retrieved from user_nobless
+                                response.PlayerInfo.Nobless = false; // Can be probably retrieved from user_nobless
+                                response.PlayerInfo.Time = reader.GetInt32(reader.GetOrdinal("use_time"));
+                            }
+                            else
+                            {
+                                response.ResponseCode = 500;
+                                response.ResponseMessage = "Could not find character with name: " + playerName;
+                                return response;
+                            }
+                            System.Diagnostics.Debug.WriteLine("5");
+                        }
+                    }
+                    response.ResponseCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            System.Diagnostics.Debug.WriteLine("GetPlayerInfo ReponseCode: " + response.ResponseCode);
+
+            return response;
+        }
+
+        public async Task<L2Response> EnchantItem(string playerName, int objId, int itemEnch)
+        {
+            var enchantRequest = new EnchantItemRequest
+            {
+                ObjectId = objId,
+                Username = playerName,
+                Enchant = itemEnch
+            };
+            var responseObject = await enchantRequest.SendPostRequest<L2Response>();
+
+            return responseObject;
+        }
+
+        public async Task<L2Response> SendDonation(string accountName, int amount, string transactionId, string verifySign)
+        {
+            L2Response response = new L2Response();
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    // 1. Check if the entry is already there
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT COUNT(*) FROM l2acp_donations " +
+                            "WHERE accountName = @ACCOUNT_NAME and transactionId = @TRANSACTION_ID and verificationSign = @VERIFICATION_SIGN";
+                        cmd.Parameters.AddWithValue("@ACCOUNT_NAME", accountName);
+                        cmd.Parameters.AddWithValue("@TRANSACTION_ID", transactionId);
+                        cmd.Parameters.AddWithValue("@VERIFICATION_SIGN", verifySign);
+
+                        int count = (int)cmd.ExecuteScalar();
+                        if (count > 0)
+                        {
+                            response.ResponseCode = 500;
+                            response.ResponseMessage = "Donation already exists";
+                            return response;
+                        }
+                    }
+
+                    // 2. Create the donation entry
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "INSERT INTO l2acp_donations (accountName, amount, tranactionId, verificationSign) values (@ACCOUNT_NAME, @AMOUNT, @TRANSACTION_ID, @VERIFICATION_SIGN)";
+                        cmd.Parameters.AddWithValue("@ACCOUNT_NAME", accountName);
+                        cmd.Parameters.AddWithValue("@AMOUNT", amount);
+                        cmd.Parameters.AddWithValue("@TRANSACTION_ID", transactionId);
+                        cmd.Parameters.AddWithValue("@VERIFICATION_SIGN", verifySign);
+                        if (cmd.ExecuteNonQuery() != 1)
+                        {
+                            response.ResponseCode = 500;
+                            response.ResponseMessage = "Failed to insert donation entry for account name: " + accountName;
+                            return response;
+                        }
+                    }
+
+                    // 3. Add it to account's donation points total
+                    if (!DatabaseServiceHelper.AddDonatePoints(accountName, amount))
+                    {
+                        response.ResponseCode = 500;
+                        response.ResponseMessage = "Failed to update points for account: " + accountName;
+                        return response;
+                    }
+
+                    response.ResponseCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> ChangePassword(string username, string currentPass, string newPass)
+        {
+            var response = new L2Response();
+            try
+            {
+                using (SqlConnection lin2dbDbConn = new SqlConnection(LIN2DB_CONN_STRING))
+                {
+                    lin2dbDbConn.Open();
+
+                    // 1. Verify that the account exists and that old password matches
+                    using (SqlCommand cmd = lin2dbDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT password FROM user_auth WHERE account = @USER";
+                        cmd.Parameters.AddWithValue("@USER", username);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                string currentDbPassword = GeneralExtensions.ByteArrayToString((byte[])reader["password"]);
+                                System.Diagnostics.Debug.WriteLine("Current DB password: " + currentDbPassword + ", Inserted password: " + currentPass);
+                                if (currentPass != currentDbPassword)
+                                {
+                                    System.Diagnostics.Debug.WriteLine("Passwords do not match !");
+                                    response.ResponseCode = 501;
+                                    return response;
+                                }
+                            }
+                            else
+                            {
+                                System.Diagnostics.Debug.WriteLine("Failed to retrieve account's password for ChangePassword service. Username: " + username);
+                                response.ResponseCode = 500;
+                                return response;
+                            }
+                        }
+                    }
+
+                    // 2. Update the password
+
+                    using (SqlCommand cmd = lin2dbDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "UPDATE user_auth SET password=@NEW_PASSWORD WHERE account=@ACCOUNT_NAME";
+                        cmd.Parameters.AddWithValue("@NEW_PASSWORD", ConvertHexStringToByteArray(newPass));
+                        cmd.Parameters.AddWithValue("@ACCOUNT_NAME", username);
+
+                        if (cmd.ExecuteNonQuery() != 1)
+                        {
+                            System.Diagnostics.Debug.WriteLine("Failed to update password");
+                            response.ResponseCode = 500;
+                            return response;
+                        }
+                    }
+
+                    response.ResponseCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> GetBuyList()
+        {
+            GetBuyListResponse response = new GetBuyListResponse();
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT * FROM l2acp_donateitems";
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            List<BuyListItem> donateBuyList = new List<BuyListItem>();
+                            while (reader.Read())
+                            {
+                                BuyListItem donateItem = new BuyListItem();
+                                donateItem.ItemId = reader.GetInt32(reader.GetOrdinal("itemId"));
+                                donateItem.ItemCount = reader.GetInt32(reader.GetOrdinal("itemCount"));
+                                donateItem.Enchant = reader.GetInt32(reader.GetOrdinal("enchant"));
+                                donateItem.Price = reader.GetInt32(reader.GetOrdinal("price"));
+
+                                donateBuyList.Add(donateItem);
+                            }
+                            response.BuyList = donateBuyList.ToArray();
+                        }
+                    }
+
+                    response.ResponseCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> GetBuyPrivateStoreList()
+        {
+            GetBuyPrivateStoreItemsResponse response = new GetBuyPrivateStoreItemsResponse();
+
+            response.BuyList = DatabaseServiceHelper.GetPrivateStoreItems(true).ToArray();
+
+            return response;
+        }
+
+        public async Task<L2Response> GetSellPrivateStoreList()
+        {
+            GetSellPrivateStoreItemsResponse response = new GetSellPrivateStoreItemsResponse();
+
+            response.SellList = DatabaseServiceHelper.GetPrivateStoreItems(false).ToArray();
+
+            return response;
+        }
+
+        public async Task<L2Response> BuyItem(string accountName, string modelUsername, int modelItemId, int modelItemCount, int modelEnchant,
+            int modelPrice)
+        {
+            L2Response response = new L2Response();
+
+            int numDonatePoints = DatabaseServiceHelper.GetNumDonatePoints(accountName);
+            if (numDonatePoints == -1)
+            {
+                response.ResponseCode = 500;
+                return response;
+            }
+
+            if (numDonatePoints < modelPrice)
+            {
+                response.ResponseCode = 501;
+                return response;
+            }
+
+            if (DatabaseServiceHelper.GiveItemToCharacter(modelUsername, modelItemId, modelItemCount, modelEnchant))
+            {
+                response.ResponseCode = 200;
+
+                DatabaseServiceHelper.AddDonatePoints(accountName, -1 * modelPrice);
+            }
+            else
+            {
+                response.ResponseCode = 500;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> SellPrivateStoreItem(int objectId, int buyerId, int count, string sellerName)
+        {
+            var sellRequest = new SellPrivateStoreItemRequest
+            {
+                ObjectId = objectId,
+                BuyerId = buyerId,
+                Count = count,
+                SellerName = sellerName
+            };
+
+            var responseObject = await sellRequest.SendPostRequest<L2Response>();
+            return responseObject;
+        }
+
+        public async Task<L2Response> BuyPrivateStoreItem(int objectId, int sellerId, int count, string buyerName)
+        {
+            var sellRequest = new BuyPrivateStoreItemRequest
+            {
+                ObjectId = objectId,
+                SellerId = sellerId,
+                Count = count,
+                BuyerName = buyerName
+            };
+
+            var responseObject = await sellRequest.SendPostRequest<L2Response>();
+            return responseObject;
+        }
+
+        public async Task<L2Response> GiveItem(string username, int itemId, int itemCount, int enchant)
+        {
+            L2Response response = new L2Response();
+            if (DatabaseServiceHelper.GiveItemToCharacter(username, itemId, itemCount, enchant))
+            {
+                response.ResponseCode = 200;
+            }
+            else
+            {
+                response.ResponseCode = 500;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> AnnounceTextAsync(string text)
+        {
+            // TODO
+            var responseObject = await new AnnounceRequest(text).SendPostRequest<L2Response>();
+            return responseObject;
+        }
+
+        public async Task<L2Response> GiveDonatePoints(string playerName, int donatePoints)
+        {
+            var response = new L2Response();
+            try
+            {
+                string accountName = "";
+                // 1. Get the account name for specified player
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+                    
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT account_name FROM user_data WHERE char_name=@CHAR_NAME";
+                        cmd.Parameters.AddWithValue("@CHAR_NAME", playerName);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                accountName = reader["account_name"].ToString();
+                            }
+                            else
+                            {
+                                System.Diagnostics.Debug.WriteLine("Failed to retrieve account name based on character name: " + playerName);
+                                response.ResponseCode = 500;
+                                return response;
+                            }
+                        }
+                    }
+                }
+
+                // 2. Give donate points
+                if (!DatabaseServiceHelper.AddDonatePoints(accountName, donatePoints))
+                {
+                    response.ResponseCode = 500;
+                    response.ResponseMessage = "Failed to update donate points";
+                    return response;
+                }
+
+                response.ResponseCode = 200;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> SetPlayerLevel(string playerName, int level)
+        {
+            var response = new L2Response();
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "UPDATE user_data SET Lev=@LEVEL WHERE char_name=@CHAR_NAME";
+                        cmd.Parameters.AddWithValue("@LEVEL", (byte)level);
+                        cmd.Parameters.AddWithValue("@CHAR_NAME", playerName);
+                        if (cmd.ExecuteNonQuery() != 1)
+                        {
+                            response.ResponseCode = 500;
+                            return response;
+                        }
+                    }
+                }
+
+                response.ResponseCode = 200;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> GetTopStats()
+        {
+            GetStatsResponse response = new GetStatsResponse();
+
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    // Top PvP
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT TOP 20 char_name, Lev, daily_pvp, PK, use_time, class FROM user_data ORDER BY daily_pvp DESC";
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            List<TopPlayer> topPvpPlayers = new List<TopPlayer>();
+                            while (reader.Read())
+                            {
+                                TopPlayer plr = new TopPlayer();
+                                plr.CharName = reader["char_name"].ToString();
+                                plr.Level = reader.GetByte(reader.GetOrdinal("Lev"));
+                                plr.PvpKills = reader.GetInt32(reader.GetOrdinal("daily_pvp"));
+                                plr.PkKills = reader.GetInt32(reader.GetOrdinal("PK"));
+                                plr.OnlineTime = reader.GetInt32(reader.GetOrdinal("use_time"));
+                                plr.Online = DatabaseServiceHelper.IsCharacterOnline(plr.CharName) ? 1 : 0;
+
+                                topPvpPlayers.Add(plr);
+                            }
+                            response.TopPvp = topPvpPlayers.ToArray();
+                        }
+                    }
+
+                    // Top PK
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT TOP 20 char_name, Lev, daily_pvp, PK, use_time, class FROM user_data ORDER BY PK DESC";
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            List<TopPlayer> topPkPlayers = new List<TopPlayer>();
+                            while (reader.Read())
+                            {
+                                TopPlayer plr = new TopPlayer();
+                                plr.CharName = reader["char_name"].ToString();
+                                plr.Level = reader.GetByte(reader.GetOrdinal("Lev"));
+                                plr.PvpKills = reader.GetInt32(reader.GetOrdinal("daily_pvp"));
+                                plr.PkKills = reader.GetInt32(reader.GetOrdinal("PK"));
+                                plr.OnlineTime = reader.GetInt32(reader.GetOrdinal("use_time"));
+                                plr.Online = DatabaseServiceHelper.IsCharacterOnline(plr.CharName) ? 1 : 0;
+
+                                topPkPlayers.Add(plr);
+                            }
+                            response.TopPk = topPkPlayers.ToArray();
+                        }
+                    }
+
+                    // Top Online
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT TOP 20 char_name, Lev, daily_pvp, PK, use_time, class FROM user_data ORDER BY use_time DESC";
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            List<TopPlayer> topOnlinePlayers = new List<TopPlayer>();
+                            while (reader.Read())
+                            {
+                                TopPlayer plr = new TopPlayer();
+                                plr.CharName = reader["char_name"].ToString();
+                                plr.Level = reader.GetByte(reader.GetOrdinal("Lev"));
+                                plr.PvpKills = reader.GetInt32(reader.GetOrdinal("daily_pvp"));
+                                plr.PkKills = reader.GetInt32(reader.GetOrdinal("PK"));
+                                plr.OnlineTime = reader.GetInt32(reader.GetOrdinal("use_time"));
+                                
+                                plr.Online = DatabaseServiceHelper.IsCharacterOnline(plr.CharName) ? 1 : 0;
+
+                                topOnlinePlayers.Add(plr);
+                            }
+                            response.TopOnline = topOnlinePlayers.ToArray();
+                        }
+                    }
+
+                    System.Diagnostics.Debug.WriteLine("-------------- OK !!!");
+
+                    response.ResponseCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> GetDonateServices()
+        {
+            GetDonateServicesResponse response = new GetDonateServicesResponse();
+
+            List<DonateService> donateServicesList = DatabaseServiceHelper.GetDonateServicesList();
+            if (donateServicesList == null)
+            {
+                response.ResponseCode = 500;
+            }
+            else
+            {
+                response.DonateServices = donateServicesList.ToArray();
+                response.ResponseCode = 200;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> RenamePlayer(string playerName, string newName)
+        {
+            var response = new L2Response();
+
+            if (playerName == newName)
+            {
+                response.ResponseCode = 501;
+                return response;
+            }
+            if (DatabaseServiceHelper.GetCharIdFromCharName(newName) != -1)
+            {
+                // Player already exists
+                response.ResponseCode = 502;
+                return response;
+            }
+
+            DonateService renameService = DatabaseServiceHelper.GetDonateServiceById(1);
+            if (renameService == null)
+            {
+                response.ResponseCode = 503;
+                return response;
+            }
+
+            if (renameService.Price < 0)
+            {
+                // Service is disabled
+                response.ResponseCode = 503;
+                return response;
+            }
+
+            string accountName = DatabaseServiceHelper.GetAccountNameFromCharName(playerName);
+            int numDonatePoints = DatabaseServiceHelper.GetNumDonatePoints(accountName);
+            if (numDonatePoints == -1)
+            {
+                response.ResponseCode = 503;
+                return response;
+            }
+            else if (numDonatePoints < renameService.Price)
+            {
+                response.ResponseCode = 504;
+                return response;
+            }
+
+            // Check name validity
+            if (newName.Length > 25 || newName.Length < 3)
+            {
+                response.ResponseCode = 500;
+                return response;
+            }
+            else if (!char.IsLetter(newName[0]))
+            {
+                response.ResponseCode = 500;
+                return response;
+            }
+            else if (!Regex.IsMatch(newName, @"^[a-zA-Z0-9]+$"))
+            {
+                response.ResponseCode = 500;
+                return response;
+            }
+
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "UPDATE user_data SET char_name=@NEW_CHAR_NAME WHERE char_name=@CHAR_NAME";
+                        cmd.Parameters.AddWithValue("@NEW_CHAR_NAME", newName);
+                        cmd.Parameters.AddWithValue("@CHAR_NAME", playerName);
+                        if (cmd.ExecuteNonQuery() != 1)
+                        {
+                            response.ResponseCode = 503;
+                            return response;
+                        }
+                    }
+                }
+
+                DatabaseServiceHelper.AddDonatePoints(accountName, -1 * renameService.Price);
+
+                response.ResponseCode = 200;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 503;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> SetNobless(string playerName)
+        {
+            L2Response response = new L2Response();
+
+            // Disabled
+            response.ResponseCode = 500;
+
+            return response;
+        }
+
+        public async Task<L2Response> ChangeSex(string playerName)
+        {
+            var response = new L2Response();
+
+            DonateService service = DatabaseServiceHelper.GetDonateServiceById(4);
+            if (service == null)
+            {
+                response.ResponseCode = 501;
+                return response;
+            }
+            if (service.Price < 0)
+            {
+                // Service is disabled
+                response.ResponseCode = 501;
+                return response;
+            }
+
+            string accountName = DatabaseServiceHelper.GetAccountNameFromCharName(playerName);
+            int numDonatePoints = DatabaseServiceHelper.GetNumDonatePoints(accountName);
+            if (numDonatePoints == -1)
+            {
+                response.ResponseCode = 501;
+                return response;
+            }
+            else if (numDonatePoints < service.Price)
+            {
+                response.ResponseCode = 500;
+                return response;
+            }
+
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    byte gender = 0;
+
+                    // 1. Get current gender
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT gender FROM user_data WHERE char_name=@CHAR_NAME";
+                        cmd.Parameters.AddWithValue("@CHAR_NAME", playerName);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                gender = reader.GetByte(reader.GetOrdinal("gender"));
+                            }
+                            else
+                            {
+                                System.Diagnostics.Debug.WriteLine("Failed to retrieve account name based on character name: " + playerName);
+                                response.ResponseCode = 501;
+                                return response;
+                            }
+                        }
+                    }
+
+                    gender = gender == 0 ? gender = 1 : gender = 0;
+
+                    // 2. Change it to opposite gender
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "UPDATE user_data SET gender=@NEW_GENDER WHERE char_name=@CHAR_NAME";
+                        cmd.Parameters.AddWithValue("@NEW_GENDER", gender);
+                        cmd.Parameters.AddWithValue("@CHAR_NAME", playerName);
+                        if (cmd.ExecuteNonQuery() != 1)
+                        {
+                            response.ResponseCode = 501;
+                            return response;
+                        }
+                    }
+                }
+
+                DatabaseServiceHelper.AddDonatePoints(accountName, -1 * service.Price);
+
+                response.ResponseCode = 200;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 501;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> ResetPk(string playerName)
+        {
+            var response = new L2Response();
+
+            DonateService service = DatabaseServiceHelper.GetDonateServiceById(3);
+            if (service == null)
+            {
+                response.ResponseCode = 500;
+                return response;
+            }
+            if (service.Price < 0)
+            {
+                // Service is disabled
+                response.ResponseCode = 500;
+                return response;
+            }
+
+            string accountName = DatabaseServiceHelper.GetAccountNameFromCharName(playerName);
+            int numDonatePoints = DatabaseServiceHelper.GetNumDonatePoints(accountName);
+            if (numDonatePoints == -1)
+            {
+                response.ResponseCode = 500;
+                return response;
+            }
+            else if (numDonatePoints < service.Price)
+            {
+                response.ResponseCode = 501;
+                return response;
+            }
+
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    // Check if player already has 0 PKs
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT PK FROM user_data WHERE char_name=@CHAR_NAME";
+                        cmd.Parameters.AddWithValue("@CHAR_NAME", playerName);
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                int numPKs = reader.GetInt32(reader.GetOrdinal("PK"));
+                                if (numPKs == 0)
+                                {
+                                    response.ResponseCode = 502;
+                                    return response;
+                                }
+                            }
+                            else
+                            {
+                                response.ResponseCode = 500;
+                                return response;
+                            }
+                        }
+                    }
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "UPDATE user_data SET PK=0 WHERE char_name=@CHAR_NAME";
+                        cmd.Parameters.AddWithValue("@CHAR_NAME", playerName);
+                        if (cmd.ExecuteNonQuery() != 1)
+                        {
+                            response.ResponseCode = 500;
+                            return response;
+                        }
+                    }
+                }
+
+                DatabaseServiceHelper.AddDonatePoints(accountName, -1 * service.Price);
+
+                response.ResponseCode = 200;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> GetAllPlayers()
+        {
+            var response = new GetAllPlayerNamesResponse();
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT char_name FROM user_data";
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            List<string> charNames = new List<string>();
+                            while (reader.Read())
+                            {
+                                charNames.Add(reader["char_name"].ToString());
+                            }
+                            response.AllPlayerNames = charNames.ToArray();
+                        }
+                    }
+
+                    response.ResponseCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> Punish(int punishId, string playerName, int time)
+        {
+            var response = new L2Response();
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    int charId = DatabaseServiceHelper.GetCharIdFromCharName(playerName);
+                    if (charId == -1)
+                    {
+                        System.Diagnostics.Debug.WriteLine("1");
+                        response.ResponseCode = 502;
+                        return response;
+                    }
+
+                    bool on = true;
+                    if (punishId > 4)
+                    {
+                        punishId -= 4;
+                        on = false;
+                    }
+                    if (punishId > 4)
+                    {
+                        System.Diagnostics.Debug.WriteLine("2");
+                        response.ResponseCode = 502;
+                        time = 0;
+                        return response;
+                    }
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "lin_SetPunish";
+                        cmd.CommandType = CommandType.StoredProcedure;
+                        cmd.Parameters.AddWithValue("@char_id", charId);
+                        cmd.Parameters.AddWithValue("@punish_id", punishId);
+                        cmd.Parameters.AddWithValue("@punish_on", on ? 1 : 0);
+                        cmd.Parameters.AddWithValue("@remain", time);
+
+                        cmd.ExecuteNonQuery();
+                    }
+
+                    response.ResponseCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> GetAllOnlinePlayersForMap()
+        {
+            GetAllOnlinePlayersForMapResponse response = new GetAllOnlinePlayersForMapResponse();
+
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT char_name, xloc, yloc, Lev, nickname FROM user_data with (nolock) WHERE login>logout";
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            List<MapPlayer> onlinePlayers = new List<MapPlayer>();
+                            while (reader.Read())
+                            {
+                                MapPlayer plr = new MapPlayer();
+                                plr.Name = reader["char_name"].ToString();
+                                plr.Title = reader["nickname"].ToString();
+                                plr.Level = reader.GetByte(reader.GetOrdinal("Lev"));
+                                plr.X = reader.GetInt32(reader.GetOrdinal("xloc"));
+                                plr.Y = reader.GetInt32(reader.GetOrdinal("yloc"));
+
+                                onlinePlayers.Add(plr);
+                            }
+                            response.MapPlayers = onlinePlayers.ToArray();
+                        }
+                    }
+
+                    response.ResponseCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> GetAllBossesForMap()
+        {
+            GetLiveRbsForMapResponse response = new GetLiveRbsForMapResponse();
+
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT * FROM npc_boss WHERE alive=1";
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            List<MapMob> bossList = new List<MapMob>();
+                            while (reader.Read())
+                            {
+                                MapMob boss = new MapMob();
+                                boss.Name = reader["npc_db_name"].ToString();
+                                boss.MaxHp = reader.GetInt32(reader.GetOrdinal("hp"));
+                                boss.CurrentHp = boss.MaxHp;
+                                boss.Level = 1;// reader.GetByte(reader.GetOrdinal("Lev"));
+                                boss.X = reader.GetInt32(reader.GetOrdinal("pos_x"));
+                                boss.Y = reader.GetInt32(reader.GetOrdinal("pos_y"));
+
+                                bossList.Add(boss);
+                            }
+                            response.MapMobs = bossList.ToArray();
+                        }
+                    }
+
+                    response.ResponseCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> SpawnNpc(int npcId, int x, int y)
+        {
+            var request = new SpawnNpcRequest
+            {
+                NpcId = npcId,
+                X = x,
+                Y = y
+            };
+
+            var responseObject = await request.SendPostRequest<L2Response>();
+            return responseObject;
+        }
+
+        public async Task<L2Response> SetDonateList(AdminDonateListViewmodel[] items)
+        {
+            var response = new L2Response();
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "TRUNCATE TABLE l2acp_donateitems";
+                        cmd.ExecuteNonQuery();
+                    }
+
+                    foreach (AdminDonateListViewmodel item in items)
+                    {
+                        using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                        {
+                            cmd.CommandText = "INSERT INTO l2acp_donateitems (itemId, itemCount, enchant, price) " +
+                                "VALUES (@ITEM_ID, @ITEM_COUNT, @ENCHANT, @PRICE)";
+                            cmd.Parameters.AddWithValue("@ITEM_ID", item.itemid);
+                            cmd.Parameters.AddWithValue("@ITEM_COUNT", item.itemcount);
+                            cmd.Parameters.AddWithValue("@ENCHANT", item.itemenchant);
+                            cmd.Parameters.AddWithValue("@PRICE", item.itemprice);
+                            cmd.ExecuteNonQuery();
+                        }
+                    }
+
+                    response.ResponseCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                response.ResponseCode = 500;
+                response.ResponseMessage = ex.Message;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> RestartServer(int seconds)
+        {
+            var responseObject = await new RestartServerRequest(seconds).SendPostRequest<L2Response>();
+            return responseObject;
+        }
+
+
+        public async Task<L2Response> GetLuckyWheelList()
+        {
+            LuckyWheelListResponse response = new LuckyWheelListResponse();
+
+            var items = DatabaseServiceHelper.GetLuckyWheelListHelper();
+            if (items != null)
+            {
+                response.Items = items.ToArray();
+                response.ResponseCode = 200;
+            }
+            else
+            {
+                response.ResponseCode = 500;
+            }
+
+            return response;
+        }
+
+        public async Task<L2Response> GetAnalyticsPlayers()
+        {
+            // TODO
+            GetAnalyticsPlayersResponse response = new GetAnalyticsPlayersResponse();
+
+            List<AnalyticsPlayerData> list = new List<AnalyticsPlayerData>();
+            var item = new AnalyticsPlayerData();
+            item.Count = 500;
+            item.Timestamp = 0;
+            list.Add(item);
+
+            response.PlayerData = list.ToArray();
+            response.ResponseCode = 200;
+
+            return response;
+        }
+
+        public async Task<L2Response> SpinLuckyWheel(string playername)
+        {
+            LuckyWheelSpinResponse response = new LuckyWheelSpinResponse();
+
+            var items = DatabaseServiceHelper.GetLuckyWheelListHelper();
+            if (items != null)
+            {
+                Dictionary<int, double> itemIdToUpperLimitChance = new Dictionary<int, double>();
+
+                double totalChance = 0.0;
+                int itemIdx = 0;
+                foreach (var item in items)
+                {
+                    totalChance += item.Chance;
+                    itemIdToUpperLimitChance.Add(itemIdx, totalChance);
+                    itemIdx++;
+                }
+
+                double random = (new Random()).NextDouble() * totalChance;
+                response.Item = null;
+                itemIdx = 0;
+                foreach (var item in items)
+                {
+                    if (random <= itemIdToUpperLimitChance[itemIdx])
+                    {
+                        response.Item= item;
+                        break;
+                    }
+                    itemIdx++;
+                }
+
+                if (response.Item == null)
+                {
+                    response.ResponseCode = 500;
+                }
+                else
+                {
+                    string accountName = DatabaseServiceHelper.GetAccountNameFromCharName(playername);
+                    DatabaseServiceHelper.AddDonatePoints(accountName, -5);
+                    DatabaseServiceHelper.GiveItemToCharacter(playername, response.Item.ItemId, response.Item.Count, 0);
+                    response.ResponseCode = 200;
+                }
+            }
+            else
+            {
+                response.ResponseCode = 500;
+            }
+
+            return response;
+        }
+    }
+}
+ 
+ 

--- a/src/L2ACP/Services/DatabaseRequestService.cs
+++ b/src/L2ACP/Services/DatabaseRequestService.cs
@@ -40,8 +40,6 @@ namespace L2ACP.Services
 
         public async Task<L2Response> LoginUser(string username, string password)
         {
-            System.Diagnostics.Debug.WriteLine("Requested username: " + username + ", Requested password: " + password);
-
             L2Response response = new L2Response();
             try
             {
@@ -456,7 +454,6 @@ namespace L2ACP.Services
                             if (reader.Read())
                             {
                                 string currentDbPassword = GeneralExtensions.ByteArrayToString((byte[])reader["password"]);
-                                System.Diagnostics.Debug.WriteLine("Current DB password: " + currentDbPassword + ", Inserted password: " + currentPass);
                                 if (currentPass != currentDbPassword)
                                 {
                                     System.Diagnostics.Debug.WriteLine("Passwords do not match !");

--- a/src/L2ACP/Services/DatabaseServiceHelper.cs
+++ b/src/L2ACP/Services/DatabaseServiceHelper.cs
@@ -1,0 +1,556 @@
+﻿/*
+ * Copyright (C) 2018 Petr Jasicek
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ * 
+ * L2ACP is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using L2ACP.Models;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace L2ACP.Services
+{
+    public class DatabaseServiceHelper
+    {
+        private static string LIN2WORLD_CONN_STRING = Startup.Configuration.GetValue<string>("ConnectionString_lin2world");
+        private static string LIN2USER_CONN_STRING = Startup.Configuration.GetValue<string>("ConnectionString_lin2user");
+        private static string LIN2DB_CONN_STRING = Startup.Configuration.GetValue<string>("ConnectionString_lin2db");
+
+        public static int GetNumDonatePoints(string accountName)
+        {
+            int numDonatePoints = -1;
+            try
+            {
+                using (SqlConnection lin2dbDbConn = new SqlConnection(LIN2DB_CONN_STRING))
+                {
+                    lin2dbDbConn.Open();
+
+                    using (SqlCommand cmd = lin2dbDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT donatepoints FROM user_auth WHERE account = @USER";
+                        cmd.Parameters.AddWithValue("@USER", accountName);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                numDonatePoints = reader.GetInt32(reader.GetOrdinal("donatepoints"));
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                numDonatePoints = -1;
+            }
+
+            return numDonatePoints;
+        }
+
+        public static bool AddDonatePoints(string accountName, int numPoints)
+        {
+            try
+            {
+                using (SqlConnection lin2dbDbConn = new SqlConnection(LIN2DB_CONN_STRING))
+                {
+                    lin2dbDbConn.Open();
+
+                    using (SqlCommand cmd = lin2dbDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "UPDATE user_auth SET donatepoints=(donatepoints + @NUM_POINTS) WHERE account=@ACCOUNT_NAME";
+                        cmd.Parameters.AddWithValue("@NUM_POINTS", numPoints);
+                        cmd.Parameters.AddWithValue("@ACCOUNT_NAME", accountName);
+                        if (cmd.ExecuteNonQuery() != 1)
+                        {
+                            return false;
+                        }
+
+                        return true;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("AddDonatePoints: Failed to execute query. Exception: " + ex.Message);
+                return false;
+            }
+
+            return false;
+        }
+
+        public static string GetAccountNameFromCharName(string charName)
+        {
+            string accountName = "";
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT account_name FROM user_data WHERE char_name = @CHAR_NAME";
+                        cmd.Parameters.AddWithValue("@CHAR_NAME", charName);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                accountName = reader["account_name"].ToString();
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                accountName = "";
+            }
+
+            return accountName;
+        }
+
+        public static int GetCharIdFromCharName(string charName)
+        {
+            int charId = -1;
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT char_id FROM user_data WHERE char_name = @CHAR_NAME";
+                        cmd.Parameters.AddWithValue("@CHAR_NAME", charName);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                charId = reader.GetInt32(reader.GetOrdinal("char_id"));
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                charId = -1;
+            }
+
+            return charId;
+        }
+
+        public static string GetCharNameFromCharId(int charId)
+        {
+            string charName = "";
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT char_name FROM user_data WHERE char_id = @CHAR_ID";
+                        cmd.Parameters.AddWithValue("@CHAR_ID", charId);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                charName = reader["char_name"].ToString();
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                charName = "";
+            }
+
+            return charName;
+        }
+
+        public static List<DonateService> GetDonateServicesList()
+        {
+            List<DonateService> donateServices = new List<DonateService>();
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT * FROM l2acp_donateservices";
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            while (reader.Read())
+                            {
+                                DonateService donateService = new DonateService();
+                                donateService.ServiceId = reader.GetInt32(reader.GetOrdinal("serviceid"));
+                                donateService.ServiceName = reader["servicename"].ToString();
+                                donateService.Price = reader.GetInt32(reader.GetOrdinal("price"));
+
+                                donateServices.Add(donateService);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                donateServices = null;
+            }
+
+            return donateServices;
+        }
+
+        public static DonateService GetDonateServiceById(int id)
+        {
+            DonateService donateService = null;
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT * FROM l2acp_donateservices WHERE serviceid=@SERVICE_ID";
+                        cmd.Parameters.AddWithValue("@SERVICE_ID", id);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                donateService = new DonateService();
+                                donateService.ServiceId = reader.GetInt32(reader.GetOrdinal("serviceid"));
+                                donateService.ServiceName = reader["servicename"].ToString();
+                                donateService.Price = reader.GetInt32(reader.GetOrdinal("price"));
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                donateService = null;
+            }
+
+            return donateService;
+        }
+
+        public static bool GiveItemToCharacter(string username, int itemId, int itemCount, int enchant)
+        {
+            int charId = GetCharIdFromCharName(username);
+            if (charId == -1)
+            {
+                return false;
+            }
+
+            // 2) Give character the item
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "INSERT INTO ItemDelivery (char_id, item_id, item_amount, enchant)" +
+                            "VALUES (@CHAR_ID, @ITEM_ID, @ITEM_AMOUNT, @ENCHANT)";
+                        cmd.Parameters.AddWithValue("@CHAR_ID", charId);
+                        cmd.Parameters.AddWithValue("@ITEM_ID", itemId);
+                        cmd.Parameters.AddWithValue("@ITEM_AMOUNT", itemCount);
+                        cmd.Parameters.AddWithValue("@ENCHANT", enchant);
+                        if (cmd.ExecuteNonQuery() != 1)
+                        {
+                            return false;
+                        }
+                        else
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                return false;
+            }
+
+            return false;
+        }
+
+        public static List<TradeItemAcp> GetPrivateStoreItems(bool isBuyList)
+        {
+            List<TradeItemAcp> items = new List<TradeItemAcp>();
+
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        int storeType = isBuyList ? 3 : 1;
+                        cmd.CommandText = "SELECT * FROM PrivateStore WHERE store_type=@STORE_TYPE";
+                        cmd.Parameters.AddWithValue("@STORE_TYPE", storeType);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            while (reader.Read())
+                            {
+                                int charId = reader.GetInt32(reader.GetOrdinal("char_id"));
+                                string charName = GetCharNameFromCharId(charId);
+                                for (int itemIdx = 1; itemIdx <= 8; itemIdx++)
+                                {
+                                    int itemId = reader.GetInt32(reader.GetOrdinal("item" + itemIdx.ToString() + "_id"));
+                                    if (itemId > 0)
+                                    {
+                                        TradeItemAcp item = new TradeItemAcp();
+                                        item.ItemId = itemId;
+                                        item.Count = reader.GetInt32(reader.GetOrdinal("item" + itemIdx.ToString() +  "_count"));
+                                        item.Price = reader.GetInt32(reader.GetOrdinal("item" + itemIdx.ToString() +  "_price"));
+                                        item.Enchant = reader.GetInt32(reader.GetOrdinal("item" + itemIdx.ToString() +  "_enchant"));
+                                        item.PlayerId = charId;
+                                        item.PlayerName = charName;
+                                        items.Add(item);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                return null;
+            }
+
+            return items;
+        }
+
+        private int GetCharacterTotalOnline(string charName)
+        {
+            int totalOnline = -1;
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT use_time FROM user_data WHERE char_name=@CHAR_NAME";
+                        cmd.Parameters.AddWithValue("@CHAR_NAME", charName);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                totalOnline = reader.GetInt32(reader.GetOrdinal("use_time"));
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                totalOnline = -1;
+            }
+
+            return totalOnline;
+        }
+
+        public static bool IsCharacterOnline(string charName)
+        {
+            bool isOnline = false;
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT count(*) FROM user_data with (nolock) WHERE char_name=@CHAR_NAME AND login>logout";
+                        cmd.Parameters.AddWithValue("@CHAR_NAME", charName);
+
+                        int count = (int)cmd.ExecuteScalar();
+                        if (count == 1)
+                        {
+                            return true;
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                isOnline = false;
+            }
+
+            return isOnline;
+        }
+
+        public static List<LuckyWheelItem> GetLuckyWheelListHelper()
+        {
+            List<LuckyWheelItem> items = new List<LuckyWheelItem>();
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT * FROM l2acp_luckywheelitems";
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            while (reader.Read())
+                            {
+                                LuckyWheelItem item = new LuckyWheelItem();
+                                item.ItemId = reader.GetInt32(reader.GetOrdinal("itemid"));
+                                item.Count = reader.GetInt32(reader.GetOrdinal("itemcount"));
+                                item.Chance = reader.GetDouble(reader.GetOrdinal("chance"));
+                                items.Add(item);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to execute query. Exception: " + ex.Message);
+                items = null;
+            }
+
+            return items;
+        }
+
+        public static string GetClanNameFromPledgeId(int pledgeId)
+        {
+            if (pledgeId <= 0)
+            {
+                return "";
+            }
+
+            string clanName = "";
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT name FROM Pledge WHERE pledge_id=@PLEDGE_ID";
+                        cmd.Parameters.AddWithValue("@PLEDGE_ID", pledgeId);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                clanName = reader["name"].ToString();
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                clanName = "";
+            }
+
+            return clanName;
+        }
+
+        public static string GetAllianceNameFromPledgeId(int pledgeId)
+        {
+            if (pledgeId <= 0)
+            {
+                return "";
+            }
+
+            string allianceName = "";
+            try
+            {
+                using (SqlConnection lin2worldDbConn = new SqlConnection(LIN2WORLD_CONN_STRING))
+                {
+                    lin2worldDbConn.Open();
+
+                    int allianceId = int.MinValue;
+                    using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT alliance_id FROM Pledge WHERE pledge_id=@PLEDGE_ID";
+                        cmd.Parameters.AddWithValue("@PLEDGE_ID", pledgeId);
+
+                        using (SqlDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                allianceId = reader.GetInt32(reader.GetOrdinal("alliance_id"));
+                            }
+                        }
+                    }
+
+                    if (allianceId != int.MinValue)
+                    {
+                        using (SqlCommand cmd = lin2worldDbConn.CreateCommand())
+                        {
+                            cmd.CommandText = "SELECT name FROM Alliance WHERE id=@ALLIANCE_ID";
+                            cmd.Parameters.AddWithValue("@ALLIANCE_ID", allianceId);
+
+                            using (SqlDataReader reader = cmd.ExecuteReader())
+                            {
+                                if (reader.Read())
+                                {
+                                    allianceName = reader["name"].ToString();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                allianceName = "";
+            }
+
+            return allianceName;
+        }
+    }
+}

--- a/src/L2ACP/Startup.cs
+++ b/src/L2ACP/Startup.cs
@@ -51,7 +51,14 @@ namespace L2ACP
         {
             // Add framework services.
             services.AddTransient<IAuthService, AuthService>();
-            services.AddTransient<IRequestService, RequestService>();
+            if (Startup.Configuration.GetValue<string>("TargetServerType") == "L2OFF")
+            {
+                services.AddTransient<IRequestService, DatabaseRequestService>();
+            }
+            else
+            {
+                services.AddTransient<IRequestService, RequestService>();
+            }
             services.AddSingleton<AssetManager>();
             services.AddLocalization(opts => { opts.ResourcesPath = "Resources"; });
 

--- a/src/L2ACP/Views/Home/Statistics.cshtml
+++ b/src/L2ACP/Views/Home/Statistics.cshtml
@@ -59,7 +59,7 @@
                                                 TimeSpan time = TimeSpan.FromSeconds(player.OnlineTime);
                                                 var parsed = time.ToString(@"d\:h\:m\:s").Split(':');
                                             }
-                                            <td>@parsed[0] @Localizer["days"] @parsed[1] @Localizer["mins"] @parsed[2] @Localizer["secs"]</td>
+                                            <td>@parsed[0] @Localizer["days"] @parsed[1] @Localizer["hours"] @parsed[2] @Localizer["mins"]</td>
                                             <td>
                                                 @if (player.Online == 0)
                                                 {<span class="label label-danger">@Localizer["Offline"]</span>}
@@ -103,7 +103,7 @@
                                                 TimeSpan time = TimeSpan.FromSeconds(player.OnlineTime);
                                                 var parsed = time.ToString(@"d\:h\:m\:s").Split(':');
                                             }
-                                            <td>@parsed[0] @Localizer["days"] @parsed[1] @Localizer["mins"] @parsed[2] @Localizer["secs"]</td>
+                                            <td>@parsed[0] @Localizer["days"] @parsed[1] @Localizer["hours"] @parsed[2] @Localizer["mins"]</td>
                                             <td>
                                                 @if (player.Online == 0)
                                                 {<span class="label label-danger">@Localizer["Offline"]</span>}
@@ -147,7 +147,7 @@
                                                 TimeSpan time = TimeSpan.FromSeconds(player.OnlineTime);
                                                 var parsed = time.ToString(@"d\:h\:m\:s").Split(':');
                                             }
-                                            <td>@parsed[0] @Localizer["days"] @parsed[1] @Localizer["mins"] @parsed[2] @Localizer["secs"]</td>
+                                            <td>@parsed[0] @Localizer["days"] @parsed[1] @Localizer["hours"] @parsed[2] @Localizer["mins"]</td>
                                             <td>
                                                 @if (player.Online == 0)
                                                 {<span class="label label-danger">@Localizer["Offline"]</span>}

--- a/src/L2ACP/Views/Shared/_Layout.cshtml
+++ b/src/L2ACP/Views/Shared/_Layout.cshtml
@@ -129,7 +129,7 @@
                 <li>
                     <a  data-toggle="modal" data-target="#donateModal" href="javascript:void(0)"><i class="fa fa-money"></i> <span class="nav-label">@Localizer["Donate"]</span></a>
                 </li>
-                @if (Context.GetAccountInfo()?.AccessLevel > 100)
+                @if (Context.HasAdminAccess())
                 {
                     <li class="@((string) ViewContext.RouteData.Values["controller"] == "Admin" ? "active" : string.Empty)">
                         <a href="#"><i class="fa fa-users"></i> <span class="nav-label">@Localizer["Admin"]</span><span class="fa arrow"></span></a>

--- a/src/L2ACP/Views/Shared/_LiveMap.cshtml
+++ b/src/L2ACP/Views/Shared/_LiveMap.cshtml
@@ -13,6 +13,7 @@
     You should have received a copy of the GNU General Public License along with
     this program. If not, see <http://www.gnu.org/licenses/>.
 *@
+@using L2ACP.Extensions
 @using L2ACP.Services
 @using Microsoft.AspNetCore.Mvc.Localization
 @inject AssetManager AssetManager
@@ -23,61 +24,84 @@
 
 
 <div class="wrapper wrapper-content animated fadeIn">
-    <div class="row" style="margin-bottom: 15px;">
-        <div class="col-lg-12">
-            <select id="npcsSelect" class="form-control m-b" asp-items='new SelectList(data, "NpcId","Name")' name="npcs">
-                <option selected="selected" disabled="disabled">@Localizer["Please select an NPC to spawn"]</option>
-            </select>
+    @if (Context.GetTargetServerType() != "L2OFF")
+    {
+        <div class="row" style="margin-bottom: 15px;">
+            <div class="col-lg-12">
+                <select id="npcsSelect" class="form-control m-b" asp-items='new SelectList(data, "NpcId","Name")' name="npcs">
+                    <option selected="selected" disabled="disabled">@Localizer["Please select an NPC to spawn"]</option>
+                </select>
+            </div>
         </div>
-    </div>
+    }
+    
     <div class="mapwrapper" style="position: relative; overflow-x: auto;">
         <img src="images/map.jpg"/>
     </div>
 </div>
 
-
-<script>
-    $('#npcsSelect').select2();
-
-    $('.mapwrapper').click(function (e) {
-        if ($('#npcsSelect').val() == null) {
-            toastr["error"]("@Localizer["Select an npc if you want to spawn it."]");
-            return false;
+@if (Context.GetTargetServerType() == "L2OFF")
+{
+    <script>
+        function getLiveMapData()
+        {
+            $.get("/admin/getLiveMapData", function(data) {
+                $(".mapObj").remove();
+                    for (var i = 0; i < data.length; i++)
+                    {
+                        var img = $('<img class="mapObj"  data-toggle="tooltip" data-html="true" title="Name: ' + data[i].name + '" style="position: absolute; top: ' + data[i].y + 'px; left: ' + data[i].x + 'px;">');
+                        img.attr('src', '/images/mark.gif');
+                        img.appendTo('.mapwrapper');
+                    }
+                $('[data-toggle="tooltip"]').tooltip();
+                });
         }
 
+        getLiveMapData();
+        setInterval(getLiveMapData, 5000);
+    </script>
+}
+else
+{
+    <script>
+        $('#npcsSelect').select2();
 
-        var offset = $(this).offset();
-        var ingameX = 200 * ((e.pageX - offset.left) - 116) - 107823;
-        var ingameY = 200 * ((e.pageY - offset.top) - 2580) + 255420;
-        var npcId = $('#npcsSelect').val();
-        console.log(ingameX);
-        console.log(ingameY);
-        $.post("/admin/spawnnpc", { 'NpcId': npcId, 'X': ingameX, 'Y': ingameY}, function( data ) {
-            if (data.startsWith("ok:")) {
-                toastr["success"](data.replace("ok:", ""));
-                $('#npcsSelect').val(null);
-                $('#npcsSelect').change();
-            } else {
-                toastr["error"](data);
+        $('.mapwrapper').click(function (e) {
+            if ($('#npcsSelect').val() == null) {
+                toastr["error"]("@Localizer["Select an npc if you want to spawn it."]");
+                return false;
             }
+
+            var offset = $(this).offset();
+            var ingameX = 200 * ((e.pageX - offset.left) - 116) - 107823;
+            var ingameY = 200 * ((e.pageY - offset.top) - 2580) + 255420;
+            var npcId = $('#npcsSelect').val();
+            console.log(ingameX);
+            console.log(ingameY);
+            $.post("/admin/spawnnpc", { 'NpcId': npcId, 'X': ingameX, 'Y': ingameY}, function( data ) {
+                if (data.startsWith("ok:")) {
+                    toastr["success"](data.replace("ok:", ""));
+                    $('#npcsSelect').val(null);
+                    $('#npcsSelect').change();
+                } else {
+                    toastr["error"](data);
+                }
+            });
         });
-    });
 
-    
+        function getLiveMapData() {
+            $.get("/admin/getLiveMapData", function (data) {
+                $(".mapObj").remove();
+                for (var i = 0; i < data.length; i++) {
+                    var img = $('<img class="mapObj"  data-toggle="tooltip" data-html="true" title="Name: ' + data[i].name + '" style="position: absolute; top: ' + data[i].y + 'px; left: ' + data[i].x + 'px;">');
+                    img.attr('src', '/images/mark.gif');
+                    img.appendTo('.mapwrapper');
+                }
+                $('[data-toggle="tooltip"]').tooltip();
+            });
+        }
 
-    function getLiveMapData() {
-        $.get("/admin/getLiveMapData", function (data) {
-            $(".mapObj").remove();
-            for (var i = 0; i < data.length; i++) {
-                var img = $('<img class="mapObj"  data-toggle="tooltip" data-html="true" title="Name: ' + data[i].name + '" style="position: absolute; top: ' + data[i].y + 'px; left: ' + data[i].x + 'px;">');
-                img.attr('src', '/images/mark.gif');
-                img.appendTo('.mapwrapper');
-            }
-            $('[data-toggle="tooltip"]').tooltip(); 
-        });
-    }
-
-    getLiveMapData();
-    setInterval(getLiveMapData, 5000);
-
-</script>
+        getLiveMapData();
+        setInterval(getLiveMapData, 5000);
+    </script>
+}

--- a/src/L2ACP/Views/Shared/_PlayerManagment.cshtml
+++ b/src/L2ACP/Views/Shared/_PlayerManagment.cshtml
@@ -13,6 +13,7 @@
     You should have received a copy of the GNU General Public License along with
     this program. If not, see <http://www.gnu.org/licenses/>.
 *@
+@using L2ACP.Extensions
 @using L2ACP.Services
 @using Microsoft.AspNetCore.Mvc.Localization
 @model string[]
@@ -89,7 +90,10 @@
                                         <button type="button" id="banCharBtn" class="btn btn-primary">@Localizer["Ban Character"]</button>
                                         <button type="button" id="banChatBtn" class="btn btn-primary">@Localizer["Ban Chat"]</button>
                                         <button type="button" id="jailBtn" class="btn btn-primary">@Localizer["Jail Character"]</button>
-                                        <button type="button" id="kickBtn" class="btn btn-primary">@Localizer["Kick Character"]</button>
+                                        @if (Context.GetTargetServerType() != "L2OFF")
+                                        {
+                                            <button type="button" id="kickBtn" class="btn btn-primary">@Localizer["Kick Character"]</button>
+                                        }
                                     </div>
                                     <div class="form-group">
                                         <button type="button" id="unbanAccBtn" class="btn btn-danger">@Localizer["Unban Account"]</button>

--- a/src/L2ACP/appsettings.json
+++ b/src/L2ACP/appsettings.json
@@ -1,14 +1,18 @@
 ﻿{
-  "ApiEndpoint": "http://217.182.71.169:8000/api",
-  "ApiKey": "elfocrash",
-  "CryptoKey": "MnFfhZdXUn3u49c7AaejOL8FN58meFb9",
-  "CryptoSalt": "4XPjl3jiEITf",
-  "Logging": {
-    "IncludeScopes": false,
-    "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
+    "ApiEndpoint": "http://127.0.0.1:8000/api",
+    "ApiKey": "elfocrash",
+    "CryptoKey": "MnFfhZdXUn3u49c7AaejOL8FN58meFb9",
+    "CryptoSalt": "4XPjl3jiEITf",
+    "TargetServerType": "L2OFF",
+    "PasswordHashType": "Default",
+    "ConnectionString_lin2world": "Data Source=PJASICEK-PC\\SQLEXPRESS;Initial Catalog=lin2world;Integrated Security=True",
+    "ConnectionString_lin2db": "Data Source=PJASICEK-PC\\SQLEXPRESS;Initial Catalog=lin2db;Integrated Security=True",
+    "Logging": {
+        "IncludeScopes": false,
+        "LogLevel": {
+            "Default": "Debug",
+            "System": "Information",
+            "Microsoft": "Information"
+        }
     }
-  }
 }

--- a/src/L2ACP/appsettings.json
+++ b/src/L2ACP/appsettings.json
@@ -3,7 +3,7 @@
     "ApiKey": "elfocrash",
     "CryptoKey": "MnFfhZdXUn3u49c7AaejOL8FN58meFb9",
     "CryptoSalt": "4XPjl3jiEITf",
-    "TargetServerType": "L2OFF",
+    "TargetServerType": "L2J",
     "PasswordHashType": "Default",
     "ConnectionString_lin2world": "Data Source=PJASICEK-PC\\SQLEXPRESS;Initial Catalog=lin2world;Integrated Security=True",
     "ConnectionString_lin2db": "Data Source=PJASICEK-PC\\SQLEXPRESS;Initial Catalog=lin2db;Integrated Security=True",

--- a/src/L2ACP/web.config
+++ b/src/L2ACP/web.config
@@ -4,7 +4,7 @@
   <!--
     Configure your application settings in appsettings.json. Learn more at http://go.microsoft.com/fwlink/?LinkId=786380
   -->
-
+    
   <system.webServer>
     <handlers>
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>


### PR DESCRIPTION
Hi, this commit makes running your L2ACP on L2OFF based servers possible with changes described in updated README.md

Since there would be way too much effort to integrate REST API client on L2OFF extender's side (it needs to be compiled with VS 2005 toolchain, I did not find any suitable REST API libs for that) I made it work with L2OFF's database directly - with some additions in enclosed L2OFF_L2ACP.SQL script.

This feature does not harm original L2ACP with L2J server in any way, if it is turned off, all its previous features are untouched. L2OFF server functionality is turned on by setting "TargetServerType" to "L2OFF" in appsettings.json. If it is set to "L2J" then everything works like if this feature was not there.

Some features in L2OFF are disabled (like spawning NPCs in admin control view) because without extender's modification there is no way to spawn NPCs in real time.

One important difference between L2OFF and L2J in access control (admin vs user): L2J uses Access Level to determine various user priviliges if I am not wrong, in L2OFF admin's account is determined via "builder level" set in database. That is why in L2OFF case if AccessLevel > 0, then it the account is considered as admin (if AccessLevel == 0 then it is regular user)

Things that do not work at the moment:
Admin -> Analytics (This would require making a thread in the extender to log the information at set intervals)
Admin -> Control Area -> Server Management (Again, I only work with database, for this I would need to make some job in database which extender would in effect process)
User -> Services -> Player Services -> (*) (For these services to take effect server restart is required, same reason as above)

Video:

https://www.youtube.com/watch?v=A564-fvSj-s&feature=youtu.be